### PR TITLE
Show chocobo warning in non-city outposts

### DIFF
--- a/NoTankYou/System/Modules/Chocobo.cs
+++ b/NoTankYou/System/Modules/Chocobo.cs
@@ -24,7 +24,7 @@ public unsafe class Chocobo : ModuleBase
 
     protected override bool ShouldEvaluate(IPlayerData playerData)
     {
-        if (GameMain.IsInSanctuary()) return false;
+        if (GameMain.IsInSanctuary() && UIState.Instance()->Buddy.Companion.CurrentHealth == 0) return false;
         if (Condition.IsBoundByDuty()) return false;
         if (GetConfig<ChocoboConfiguration>().DisableInCombat && Condition.IsInCombat()) return false;
         if (playerData.GetObjectId() != Service.ClientState.LocalPlayer?.ObjectId) return false;


### PR DESCRIPTION
Outposts like Summerford Farms in the open world are considered Sanctuaries. But chocobos can be summoned and the timer continues to tick down. This change shows the chocobo warning in outposts so that it can be refreshed before the chocobo buff is lost.