### PR TITLE
Fix Status ID for Prospect

### DIFF
--- a/NoTankYou/System/Modules/Gatherers.cs
+++ b/NoTankYou/System/Modules/Gatherers.cs
@@ -19,7 +19,7 @@ public class Gatherers : ModuleBase
     
     private readonly List<(uint ClassJob, uint MinLevel, uint StatusId, uint ActionId)> data = new()
     {
-        ( MinerClassJobId, 1, 255, 227 ),
+        ( MinerClassJobId, 1, 225, 227 ),
         ( MinerClassJobId, 46, 222, 238 ),
         ( BotanistClassJobId, 1, 217, 210 ),
         ( BotanistClassJobId, 46, 221, 221 ),


### PR DESCRIPTION
When enabling the Gatherer warnings, the Prospect warning is up permanently, whether or not you enable Prospect. Looks like the action ID was either typoed or changed since this was added, on my client it looks to be action ID 225.

![Screenshot of the status effect debugging in game](https://github.com/MidoriKami/NoTankYou/assets/22138688/f198c4d5-d62f-4555-9447-7b9679cb5dde)
