### PR TITLE
Fix job icon & title reset

### DIFF
--- a/NoTankYou/System/PartyListController.cs
+++ b/NoTankYou/System/PartyListController.cs
@@ -71,7 +71,6 @@ public class PartyListController : IDisposable {
 
         foreach (var (member, warning) in ActiveWarnings) {
             if (member is null) continue;
-            if (warning is null) continue;
             
             member.DrawWarning(warning);
         }
@@ -82,7 +81,6 @@ public class PartyListController : IDisposable {
 
         foreach (var (member, warning) in ActiveWarnings) {
             if (member is null) continue;
-            if (warning is null) continue;
             
             member.DrawNative(warning);
         }


### PR DESCRIPTION
Fix an issue when you disabled a warning at the right time, and the job icon would disappear and the glowing name would stay red.

Related to https://github.com/MidoriKami/NoTankYou/issues/56

Issue was skipping if the warning was null, which was skipping the reset; DrawWarning() & DrawNative() function already handle null value for warning corrrectly.