### PR TITLE
Update KamiToolKit to fix issue with removed structs in CS and bump plugin version

### DIFF
--- a/NoTankYou/NoTankYou.csproj
+++ b/NoTankYou/NoTankYou.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Dalamud.NET.Sdk/12.0.2">
 	<PropertyGroup>
-		<AssemblyVersion>7.2.1.0</AssemblyVersion>
+		<AssemblyVersion>7.2.1.1</AssemblyVersion>
 		<PackageProjectUrl>https://github.com/MidoriKami/NoTankYou.git</PackageProjectUrl>
 	</PropertyGroup>
 	


### PR DESCRIPTION
The old obsolete nameplate array was removed from CS in new Dalamud `stg` branches. This is already fixed in KamiToolKit, so I just updated the submodule commit and bumped the version.